### PR TITLE
Fix: Move install_requires to [options] section in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,8 +10,10 @@ long_description_content_type = text/markdown
 license = MIT
 project_urls =
     Bug Tracker = https://github.com/pyportion/pyportion/issues
-
 python_requires = >= 3.8
+
+[options]
+packages = find:
 install_requires =
     gitpython==3.1.45
     platformdirs==4.4.0
@@ -20,8 +22,3 @@ install_requires =
 [options.entry_points]
 console_scripts=
     portion=portion.__main__:main
-
-[options]
-packages = find:
-
-


### PR DESCRIPTION
This commit fixes the incorrect placement of the install_requires section in setup.cfg. The install_requires should be in the [options] section, not in [metadata]. Also reordered sections so [options] comes before [options.entry_points] for better organization.